### PR TITLE
Add support for Ricker wavelet

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -8,9 +8,9 @@ version = "1.0.0"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "42c42f2221906892ceb765dbcb1a51deeffd86d7"
+git-tree-sha1 = "345a14764e43fe927d6f5c250fe4c8e4664e6ee8"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "2.3.0"
+version = "2.4.0"
 
 [[ArnoldiMethod]]
 deps = ["DelimitedFiles", "LinearAlgebra", "Random", "SparseArrays", "Test"]
@@ -323,9 +323,9 @@ uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
 [[JLLWrappers]]
-git-tree-sha1 = "04b49c556240b62d5a799e94c63d5fc14d3c07cd"
+git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.1.4"
+version = "1.2.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -379,7 +379,7 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[LongwaveModePropagator]]
 deps = ["BetterExp", "Dates", "DiffEqCallbacks", "Interpolations", "JSON3", "LinearAlgebra", "ModifiedHankelFunctionsOfOrderOneThird", "OrdinaryDiffEq", "Parameters", "PolynomialRoots", "ProgressMeter", "Romberg", "RootsAndPoles", "StaticArrays", "StructTypes"]
-git-tree-sha1 = "75f53ebd6dba8e9cbd73f026446b46f4555584c2"
+git-tree-sha1 = "399136e5ff5c33d9567b0a7182d55d12c4617818"
 repo-rev = "master"
 repo-url = "https://github.com/fgasdia/LongwaveModePropagator.jl"
 uuid = "38c6559a-e0a7-48c6-827d-3f02e2d19cec"
@@ -387,9 +387,9 @@ version = "0.1.0"
 
 [[LoopVectorization]]
 deps = ["ArrayInterface", "DocStringExtensions", "IfElse", "LinearAlgebra", "OffsetArrays", "SLEEFPirates", "UnPack", "VectorizationBase"]
-git-tree-sha1 = "e41fb1e48028bda0a7748b56ff884634ed56fef2"
+git-tree-sha1 = "9e5f8bbdcd44cbc9ab1119cb89d1bafc88e49eb8"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
-version = "0.9.16"
+version = "0.9.17"
 
 [[MKL_jll]]
 deps = ["IntelOpenMP_jll", "Libdl", "Pkg"]
@@ -458,9 +458,9 @@ version = "0.3.4"
 
 [[OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "c6de3b9ddd48facb4305b0ec8fd55db13f94ca59"
+git-tree-sha1 = "5b644e46f71e744fac0775b885809fd82c4ca904"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.4.3"
+version = "1.5.0"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -642,9 +642,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SparseDiffTools]]
 deps = ["Adapt", "ArrayInterface", "Compat", "DataStructures", "FiniteDiff", "ForwardDiff", "LightGraphs", "LinearAlgebra", "Requires", "SparseArrays", "VertexSafeGraphs"]
-git-tree-sha1 = "a8fe04fc9048d1c1e25d4b13ec374987b0599b7b"
+git-tree-sha1 = "0eba5e11daa44fb2c4c5b4463dd541dd1b61199c"
 uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-version = "1.10.2"
+version = "1.11.0"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "OpenSpecFun_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["fgasdia <fgasdia@noreply.github.com>"]
 version = "0.0.4"
 
 [deps]
-BetterExp = "7cffe744-45fd-4178-b173-cf893948b8b7"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -13,10 +12,23 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LongwaveModePropagator = "38c6559a-e0a7-48c6-827d-3f02e2d19cec"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+CSV = "0.8"
+DSP = "0.6"
+DataFrames = "0.22"
+Interpolations = "0.13"
+JSON3 = "1"
+LongwaveModePropagator = "0.1"
+Parameters = "0.12"
+ProgressMeter = "1"
+Reexport = "0.2"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
The Ricker Wavelet pulse is necessary for modeling up in the LF band.

The original behavior and linear/exponential waveform is maintained for DFT frequencies below 50 kHz.